### PR TITLE
Updates releaser batch multiple charts into one push

### DIFF
--- a/pkg/releaser/releaser_test.go
+++ b/pkg/releaser/releaser_test.go
@@ -510,13 +510,17 @@ func TestReleaser_ReleaseNotes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeGitHub := new(FakeGitHub)
+			fakeGit := new(FakeGit)
 			r := &Releaser{
 				config: &config.Options{
 					PackagePath:      "testdata/release-packages",
 					ReleaseNotesFile: tt.releaseNotesFile,
 				},
 				github: fakeGitHub,
+				git:    fakeGit,
 			}
+			fakeGit.On("AddWorktree", mock.Anything, mock.Anything).Return("/tmp/chart-releaser-012345678", nil)
+			fakeGit.On("RemoveWorktree", mock.Anything, mock.Anything).Return(nil)
 			fakeGitHub.On("CreateRelease", mock.Anything, mock.Anything).Return(nil)
 			err := r.CreateReleases()
 			assert.NoError(t, err)


### PR DESCRIPTION
Fixes the releaser to push one time for multiple charts.