### PR TITLE
Do not merge upstream: removes all docker publishing

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -190,6 +190,11 @@ signs:
     args: ["sign-blob", "--output-signature", "${artifact}.sig", "--output-certificate", "${artifact}.pem", "${artifact}"]
     artifacts: all
 
+release:
+  github:
+    owner: incontact
+    name: chart-releaser
+
 # docker_signs:
 #   - id: images
 #     cmd: cosign

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -55,132 +55,132 @@ checksum:
 snapshot:
   name_template: "{{ .Tag }}-next"
 
-dockers:
-  - goos: linux
-    goarch: amd64
-    skip_push: "{{ ne .GitURL 'https://github.com/incontact/chart-releaser' | toYaml }}"
-    dockerfile: Dockerfile
-    use: buildx
-    image_templates:
-      # - quay.io/helmpack/chart-releaser:{{ .Tag }}-amd64
-      # - quay.io/helmpack/chart-releaser:latest-amd64
-      - ghcr.io/incontact/chart-releaser:{{ .Tag }}-amd64
-      - ghcr.io/incontact/chart-releaser:latest-amd64
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - --label=org.label-schema.schema-version=1.0
-      - --label=org.label-schema.version={{ .Version }}
-      - --label=org.label-schema.name={{ .ProjectName }}
-      - --label=org.label-schema.build-date={{ .Date }}
-      - --label=org.label-schema.description='cr - The chart release tool'
-      - --label=org.label-schema.vendor=Helm
+# dockers:
+#   - goos: linux
+#     goarch: amd64
+#     skip_push: "{{ ne .GitURL 'https://github.com/incontact/chart-releaser' | toYaml }}"
+#     dockerfile: Dockerfile
+#     use: buildx
+#     image_templates:
+#       - quay.io/helmpack/chart-releaser:{{ .Tag }}-amd64
+#       - quay.io/helmpack/chart-releaser:latest-amd64
+#       - ghcr.io/incontact/chart-releaser:{{ .Tag }}-amd64
+#       - ghcr.io/incontact/chart-releaser:latest-amd64
+#     build_flag_templates:
+#       - "--platform=linux/amd64"
+#       - --label=org.label-schema.schema-version=1.0
+#       - --label=org.label-schema.version={{ .Version }}
+#       - --label=org.label-schema.name={{ .ProjectName }}
+#       - --label=org.label-schema.build-date={{ .Date }}
+#       - --label=org.label-schema.description='cr - The chart release tool'
+#       - --label=org.label-schema.vendor=Helm
 
-  - goos: linux
-    goarch: arm64
-    skip_push: "{{ ne .GitURL 'https://github.com/incontact/chart-releaser' | toYaml }}"
-    dockerfile: Dockerfile
-    use: buildx
-    image_templates:
-      # - quay.io/helmpack/chart-releaser:{{ .Tag }}-arm64
-      # - quay.io/helmpack/chart-releaser:latest-arm64
-      - ghcr.io/incontact/chart-releaser:{{ .Tag }}-arm64
-      - ghcr.io/incontact/chart-releaser:latest-arm64
-    build_flag_templates:
-      - "--platform=linux/arm64"
-      - --label=org.label-schema.schema-version=1.0
-      - --label=org.label-schema.version={{ .Version }}
-      - --label=org.label-schema.name={{ .ProjectName }}
-      - --label=org.label-schema.build-date={{ .Date }}
-      - --label=org.label-schema.description='cr - The chart release tool'
-      - --label=org.label-schema.vendor=Helm
+#   - goos: linux
+#     goarch: arm64
+#     skip_push: "{{ ne .GitURL 'https://github.com/incontact/chart-releaser' | toYaml }}"
+#     dockerfile: Dockerfile
+#     use: buildx
+#     image_templates:
+#       - quay.io/helmpack/chart-releaser:{{ .Tag }}-arm64
+#       - quay.io/helmpack/chart-releaser:latest-arm64
+#       - ghcr.io/incontact/chart-releaser:{{ .Tag }}-arm64
+#       - ghcr.io/incontact/chart-releaser:latest-arm64
+#     build_flag_templates:
+#       - "--platform=linux/arm64"
+#       - --label=org.label-schema.schema-version=1.0
+#       - --label=org.label-schema.version={{ .Version }}
+#       - --label=org.label-schema.name={{ .ProjectName }}
+#       - --label=org.label-schema.build-date={{ .Date }}
+#       - --label=org.label-schema.description='cr - The chart release tool'
+#       - --label=org.label-schema.vendor=Helm
 
-  - goos: linux
-    goarch: arm
-    goarm: 7
-    skip_push: "{{ ne .GitURL 'https://github.com/incontact/chart-releaser' | toYaml }}"
-    dockerfile: Dockerfile
-    use: buildx
-    image_templates:
-      # - quay.io/helmpack/chart-releaser:{{ .Tag }}-armv7
-      # - quay.io/helmpack/chart-releaser:latest-armv7
-      - ghcr.io/incontact/chart-releaser:{{ .Tag }}-armv7
-      - ghcr.io/incontact/chart-releaser:latest-armv7
-    build_flag_templates:
-      - "--platform=linux/arm/v7"
-      - --label=org.label-schema.schema-version=1.0
-      - --label=org.label-schema.version={{ .Version }}
-      - --label=org.label-schema.name={{ .ProjectName }}
-      - --label=org.label-schema.build-date={{ .Date }}
-      - --label=org.label-schema.description='cr - The chart release tool'
-      - --label=org.label-schema.vendor=Helm
+#   - goos: linux
+#     goarch: arm
+#     goarm: 7
+#     skip_push: "{{ ne .GitURL 'https://github.com/incontact/chart-releaser' | toYaml }}"
+#     dockerfile: Dockerfile
+#     use: buildx
+#     image_templates:
+#       - quay.io/helmpack/chart-releaser:{{ .Tag }}-armv7
+#       - quay.io/helmpack/chart-releaser:latest-armv7
+#       - ghcr.io/incontact/chart-releaser:{{ .Tag }}-armv7
+#       - ghcr.io/incontact/chart-releaser:latest-armv7
+#     build_flag_templates:
+#       - "--platform=linux/arm/v7"
+#       - --label=org.label-schema.schema-version=1.0
+#       - --label=org.label-schema.version={{ .Version }}
+#       - --label=org.label-schema.name={{ .ProjectName }}
+#       - --label=org.label-schema.build-date={{ .Date }}
+#       - --label=org.label-schema.description='cr - The chart release tool'
+#       - --label=org.label-schema.vendor=Helm
 
-  - goos: linux
-    goarch: s390x
-    skip_push: "{{ ne .GitURL 'https://github.com/incontact/chart-releaser' | toYaml }}"
-    dockerfile: Dockerfile
-    use: buildx
-    image_templates:
-      # - quay.io/helmpack/chart-releaser:{{ .Tag }}-s390x
-      # - quay.io/helmpack/chart-releaser:latest-s390x
-      - ghcr.io/incontact/chart-releaser:{{ .Tag }}-s390x
-      - ghcr.io/incontact/chart-releaser:latest-s390x
-    build_flag_templates:
-      - "--platform=linux/s390x"
-      - --label=org.label-schema.schema-version=1.0
-      - --label=org.label-schema.version={{ .Version }}
-      - --label=org.label-schema.name={{ .ProjectName }}
-      - --label=org.label-schema.build-date={{ .Date }}
-      - --label=org.label-schema.description='cr - The chart release tool'
-      - --label=org.label-schema.vendor=Helm
+#   - goos: linux
+#     goarch: s390x
+#     skip_push: "{{ ne .GitURL 'https://github.com/incontact/chart-releaser' | toYaml }}"
+#     dockerfile: Dockerfile
+#     use: buildx
+#     image_templates:
+#       - quay.io/helmpack/chart-releaser:{{ .Tag }}-s390x
+#       - quay.io/helmpack/chart-releaser:latest-s390x
+#       - ghcr.io/incontact/chart-releaser:{{ .Tag }}-s390x
+#       - ghcr.io/incontact/chart-releaser:latest-s390x
+#     build_flag_templates:
+#       - "--platform=linux/s390x"
+#       - --label=org.label-schema.schema-version=1.0
+#       - --label=org.label-schema.version={{ .Version }}
+#       - --label=org.label-schema.name={{ .ProjectName }}
+#       - --label=org.label-schema.build-date={{ .Date }}
+#       - --label=org.label-schema.description='cr - The chart release tool'
+#       - --label=org.label-schema.vendor=Helm
 
-  - goos: linux
-    goarch: ppc64le
-    skip_push: "{{ ne .GitURL 'https://github.com/incontact/chart-releaser' | toYaml }}"
-    dockerfile: Dockerfile
-    use: buildx
-    image_templates:
-      # - quay.io/helmpack/chart-releaser:{{ .Tag }}-ppc64le
-      # - quay.io/helmpack/chart-releaser:latest-ppc64le
-      - ghcr.io/incontact/chart-releaser:{{ .Tag }}-ppc64le
-      - ghcr.io/incontact/chart-releaser:latest-ppc64le
-    build_flag_templates:
-      - "--platform=linux/ppc64le"
-      - --label=org.label-schema.schema-version=1.0
-      - --label=org.label-schema.version={{ .Version }}
-      - --label=org.label-schema.name={{ .ProjectName }}
-      - --label=org.label-schema.build-date={{ .Date }}
-      - --label=org.label-schema.description='cr - The chart release tool'
-      - --label=org.label-schema.vendor=Helm
+#   - goos: linux
+#     goarch: ppc64le
+#     skip_push: "{{ ne .GitURL 'https://github.com/incontact/chart-releaser' | toYaml }}"
+#     dockerfile: Dockerfile
+#     use: buildx
+#     image_templates:
+#       - quay.io/helmpack/chart-releaser:{{ .Tag }}-ppc64le
+#       - quay.io/helmpack/chart-releaser:latest-ppc64le
+#       - ghcr.io/incontact/chart-releaser:{{ .Tag }}-ppc64le
+#       - ghcr.io/incontact/chart-releaser:latest-ppc64le
+#     build_flag_templates:
+#       - "--platform=linux/ppc64le"
+#       - --label=org.label-schema.schema-version=1.0
+#       - --label=org.label-schema.version={{ .Version }}
+#       - --label=org.label-schema.name={{ .ProjectName }}
+#       - --label=org.label-schema.build-date={{ .Date }}
+#       - --label=org.label-schema.description='cr - The chart release tool'
+#       - --label=org.label-schema.vendor=Helm
 
-docker_manifests:
-  # - name_template: quay.io/helmpack/chart-releaser:{{ .Tag }}
-  #   image_templates:
-  #     - quay.io/helmpack/chart-releaser:{{ .Tag }}-amd64
-  #     - quay.io/helmpack/chart-releaser:{{ .Tag }}-arm64
-  #     - quay.io/helmpack/chart-releaser:{{ .Tag }}-armv7
-  #     - quay.io/helmpack/chart-releaser:{{ .Tag }}-s390x
-  #     - quay.io/helmpack/chart-releaser:{{ .Tag }}-ppc64le
-  - name_template: ghcr.io/incontact/chart-releaser:{{ .Tag }}
-    image_templates:
-      - ghcr.io/incontact/chart-releaser:{{ .Tag }}-amd64
-      - ghcr.io/incontact/chart-releaser:{{ .Tag }}-arm64
-      - ghcr.io/incontact/chart-releaser:{{ .Tag }}-armv7
-      - ghcr.io/incontact/chart-releaser:{{ .Tag }}-s390x
-      - ghcr.io/incontact/chart-releaser:{{ .Tag }}-ppc64le
-  # - name_template: quay.io/helmpack/chart-releaser:latest
-  #   image_templates:
-  #     - quay.io/helmpack/chart-releaser:latest-amd64
-  #     - quay.io/helmpack/chart-releaser:latest-arm64
-  #     - quay.io/helmpack/chart-releaser:latest-armv7
-  #     - quay.io/helmpack/chart-releaser:latest-s390x
-  #     - quay.io/helmpack/chart-releaser:latest-ppc64le
-  - name_template: ghcr.io/incontact/chart-releaser:latest
-    image_templates:
-      - ghcr.io/incontact/chart-releaser:latest-amd64
-      - ghcr.io/incontact/chart-releaser:latest-arm64
-      - ghcr.io/incontact/chart-releaser:latest-armv7
-      - ghcr.io/incontact/chart-releaser:latest-s390x
-      - ghcr.io/incontact/chart-releaser:latest-ppc64le
+# docker_manifests:
+#   - name_template: quay.io/helmpack/chart-releaser:{{ .Tag }}
+#     image_templates:
+#       - quay.io/helmpack/chart-releaser:{{ .Tag }}-amd64
+#       - quay.io/helmpack/chart-releaser:{{ .Tag }}-arm64
+#       - quay.io/helmpack/chart-releaser:{{ .Tag }}-armv7
+#       - quay.io/helmpack/chart-releaser:{{ .Tag }}-s390x
+#       - quay.io/helmpack/chart-releaser:{{ .Tag }}-ppc64le
+#   - name_template: ghcr.io/incontact/chart-releaser:{{ .Tag }}
+#     image_templates:
+#       - ghcr.io/incontact/chart-releaser:{{ .Tag }}-amd64
+#       - ghcr.io/incontact/chart-releaser:{{ .Tag }}-arm64
+#       - ghcr.io/incontact/chart-releaser:{{ .Tag }}-armv7
+#       - ghcr.io/incontact/chart-releaser:{{ .Tag }}-s390x
+#       - ghcr.io/incontact/chart-releaser:{{ .Tag }}-ppc64le
+#   - name_template: quay.io/helmpack/chart-releaser:latest
+#     image_templates:
+#       - quay.io/helmpack/chart-releaser:latest-amd64
+#       - quay.io/helmpack/chart-releaser:latest-arm64
+#       - quay.io/helmpack/chart-releaser:latest-armv7
+#       - quay.io/helmpack/chart-releaser:latest-s390x
+#       - quay.io/helmpack/chart-releaser:latest-ppc64le
+#   - name_template: ghcr.io/incontact/chart-releaser:latest
+#     image_templates:
+#       - ghcr.io/incontact/chart-releaser:latest-amd64
+#       - ghcr.io/incontact/chart-releaser:latest-arm64
+#       - ghcr.io/incontact/chart-releaser:latest-armv7
+#       - ghcr.io/incontact/chart-releaser:latest-s390x
+#       - ghcr.io/incontact/chart-releaser:latest-ppc64le
 
 signs:
   - id: all
@@ -190,11 +190,11 @@ signs:
     args: ["sign-blob", "--output-signature", "${artifact}.sig", "--output-certificate", "${artifact}.pem", "${artifact}"]
     artifacts: all
 
-docker_signs:
-  - id: images
-    cmd: cosign
-    args: ["sign", "${artifact}"]
-    artifacts: manifests
+# docker_signs:
+#   - id: images
+#     cmd: cosign
+#     args: ["sign", "${artifact}"]
+#     artifacts: manifests
 
 # brews:
 #   - repository:


### PR DESCRIPTION
Since the org doesn't allow public packages and we only need the binary for the github action, we're removing the docker publishing.